### PR TITLE
Initial changes for future pull-requests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+    "presets": [
+        "next/babel",
+        "stage-0"
+    ],
+    "plugins": [
+        "react-html-attrs"
+    ]  
+}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -12,11 +12,13 @@ export default class Layout extends Component {
     }
   }
   render () {
+    const { title, description, headerType, children } = this.props;
+
     return (
       <div style={{display: 'flex', flexDirection: 'column'}}>
-        <Head title={this.props.title} description={this.props.description} />
-        <Nav headerType={this.props.headerType} />
-        {this.props.children}
+        <Head title={title} description={description} />
+        <Nav headerType={headerType} />
+        {children}
         <Footer />
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.2/js/materialize.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "babel-plugin-react-html-attrs": "^2.0.0",
+    "babel-preset-stage-0": "^6.24.1",
     "express": "^4.15.3",
     "lru-cache": "^4.0.2",
     "next": "^2.4.3",
+    "prop-types": "^15.5.10",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-ga": "^2.2.0",


### PR DESCRIPTION
- Added .babelrc at root of directory to customize babel transpiling with provided presets : [https://github.com/zeit/next.js/#customizing-babel-config](url)

- Add babel -react-html-attr plugin to babel to allow class and for attributes without need for custom .jsx mutation to className and htmlFor:
[https://www.npmjs.com/package/babel-plugin-react-html-attrs](url)

- Destructure (ES6) this.props in the render method to DRY references and make more readable

- Import prop-types package for type checking of props and setting default props where required. In my next commit, I'll use this on the new Layout component to define a class prop that will have a default class. So rather than setting inline styles on the `<div>` you can pass a custom class for each instance it's used (if you want different layouts or even modifier classes). Also allows a default class that will be used if one isn't passed through, allowing you to style in SCSS.

