### PR TITLE
🎉  Debounce search on resources page

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel-plugin-react-html-attrs": "^2.0.0",
     "babel-preset-stage-0": "^6.24.1",
     "express": "^4.15.3",
+    "lodash.debounce": "^4.0.8",
     "lru-cache": "^4.0.2",
     "next": "^2.4.3",
     "prop-types": "^15.5.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2858,7 +2858,7 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash.debounce@^4.0.6:
+lodash.debounce@^4.0.6, lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 


### PR DESCRIPTION
Changed order of imports, npm first then personal imports. Keep it solid.
Changed `input` `onKeyUp` event to `onChange` because we got event even when tap `CTRL, SHIFT ...`
Debounce `getSearchResults` using `lodash.debounce`

What a journey. 🔥 
Learned abount next.js during this changes.

Fixes: #10 