### PR TITLE
Styled Resource Divider and Key warning fix

### DIFF
--- a/components/ResourceRow.js
+++ b/components/ResourceRow.js
@@ -4,7 +4,6 @@ const ResourceRow = props =>
   <div
     class='valign-wrapper col s12 resource-row'
     style={{
-      borderBottom: '1px solid rgba(0, 0, 0, 0.54)',
       padding: '16px'
     }}
   >
@@ -68,13 +67,6 @@ const ResourceRow = props =>
       <img src={props.img} style={{ maxHeight: '200px' }} />
 
     </div>
-    <style jsx>
-      {`
-        .resource-row:first-of-type {
-          border-top: 1px solid rgba(0, 0, 0, 0.54);
-        }
-      `}
-    </style>
   </div>
 
 export default ResourceRow

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -269,6 +269,7 @@ export default class extends React.Component {
                               : ''
                           }
                         />
+                        {idx + 1 !== this.state.data.length && <hr />}
                       </div>
                     )}
 

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -269,7 +269,8 @@ export default class extends React.Component {
                               : ''
                           }
                         />
-                        {idx + 1 !== this.state.data.length && <hr />}
+                        {idx + 1 !== this.state.data.length &&
+                          <hr className='resource-divider' />}
                       </div>
                     )}
 
@@ -308,6 +309,18 @@ export default class extends React.Component {
               }
               .resource-row:first-of-type {
                 border-top: 1px solid rgba(0, 0, 0, 0.54);
+              }
+              .resource-divider {
+                height: 1px;
+                border: 1px solid transparent;
+                background: -webkit-gradient(
+                  linear,
+                  0 0,
+                  100% 0,
+                  from(rgb(245, 245, 245)),
+                  color-stop(0.5, rgb(46, 52, 64)),
+                  to(rgb(245, 245, 245))
+                );
               }
             `}
           </style>

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -250,24 +250,26 @@ export default class extends React.Component {
                     .filter(
                       post => activeTab === 'all' || activeTab === post.acf.type
                     )
-                    .map(post =>
-                      <ResourceRow
-                        title={post.title.rendered}
-                        type={post.acf.type}
-                        author={
-                          post.acf.hasOwnProperty('author')
-                            ? post.acf.author
-                            : ''
-                        }
-                        content={post.acf.description}
-                        url={post.acf.url}
-                        price={post.acf.price}
-                        img={
-                          post.better_featured_image !== null
-                            ? post.better_featured_image.source_url
-                            : ''
-                        }
-                      />
+                    .map((post, idx) =>
+                      <div key={idx}>
+                        <ResourceRow
+                          title={post.title.rendered}
+                          type={post.acf.type}
+                          author={
+                            post.acf.hasOwnProperty('author')
+                              ? post.acf.author
+                              : ''
+                          }
+                          content={post.acf.description}
+                          url={post.acf.url}
+                          price={post.acf.price}
+                          img={
+                            post.better_featured_image !== null
+                              ? post.better_featured_image.source_url
+                              : ''
+                          }
+                        />
+                      </div>
                     )}
 
                 </div>


### PR DESCRIPTION
This replaces the borders on the rendered div with a styled `<hr />` tag after every resource, except for the last one.

Also added an index (`idx`) to use when mapping over the post resources. This both clears the React Warning for requiring a key (supplying it to a div wrapper) as well as lets us compute whether or not the element is the last one in `this.state.data` so we don't render an unnecessary `<hr />`.

**Before:**
![screen shot 2017-07-12 at 9 16 22 pm](https://user-images.githubusercontent.com/7575378/28147781-86d3c632-6748-11e7-8006-1f0485d7a62b.png)


**After:**
![screen shot 2017-07-12 at 9 17 13 pm](https://user-images.githubusercontent.com/7575378/28147792-8ec1d0dc-6748-11e7-80c1-1a385bb9015a.png)
